### PR TITLE
Fix setting log level via cmd line or config file

### DIFF
--- a/camacq/__main__.py
+++ b/camacq/__main__.py
@@ -177,7 +177,6 @@ def parse_command_line():
     parser.add_argument(
         '--log-level',
         dest=LOG_LEVEL,
-        default='INFO',
         type=check_log_level,
         help='an option to specify lowest log level to log')
     parser.add_argument(

--- a/camacq/log.py
+++ b/camacq/log.py
@@ -25,7 +25,7 @@ def check_path(path):
 
 def enable_log(config):
     """Enable logging."""
-    logging.basicConfig(level=config[LOG_LEVEL])
+    logging.basicConfig()
     root_logger = logging.getLogger()
     # basicConfig has added a StreamHandler
     # '%(log_color)s%(levelname)s:%(name)s:%(message)s'
@@ -57,3 +57,5 @@ def enable_log(config):
                 '%(asctime)s;%(name)-16s;%(levelname)-8s;%(message)s')
             filelog.setFormatter(formatter)
             logging.getLogger('').addHandler(filelog)
+    if config[LOG_LEVEL]:
+        root_logger.handlers[0].setLevel(config[LOG_LEVEL])

--- a/camacq/log.py
+++ b/camacq/log.py
@@ -25,7 +25,7 @@ def check_path(path):
 
 def enable_log(config):
     """Enable logging."""
-    logging.basicConfig()
+    logging.basicConfig(level=logging.INFO)
     root_logger = logging.getLogger()
     # basicConfig has added a StreamHandler
     # '%(log_color)s%(levelname)s:%(name)s:%(message)s'


### PR DESCRIPTION
* Setting log level via command line will always take precedence.
* If log level is not set via command line, config file setting will take effect.
* Set default log level to info.