### PR TITLE
Add release instructions and change log script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change Log
 
 ## [0.3](https://github.com/CellProfiling/cam_acq/tree/0.3) (2017-08-18)
-
 [Full Changelog](https://github.com/CellProfiling/cam_acq/compare/0.2...0.3)
 
 **Merged pull requests:**
 
+- 0.3 [\#34](https://github.com/CellProfiling/cam_acq/pull/34) ([MartinHjelmare](https://github.com/MartinHjelmare))
 - Update readme with latest option changes [\#33](https://github.com/CellProfiling/cam_acq/pull/33) ([MartinHjelmare](https://github.com/MartinHjelmare))
 - Move version to const.py [\#32](https://github.com/CellProfiling/cam_acq/pull/32) ([MartinHjelmare](https://github.com/MartinHjelmare))
 - Make settings configurable from config [\#31](https://github.com/CellProfiling/cam_acq/pull/31) [[breaking change](https://github.com/CellProfiling/cam_acq/labels/breaking%20change)] ([MartinHjelmare](https://github.com/MartinHjelmare))

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+# Release procedure
+
+- Create a release branch from develop, called the same as the release number.
+- Merge master into the release branch to make the PR mergeable.
+- Update version in `const.py`to the new version number, eg `'0.2.0'`.
+- Update `CHANGELOG.md` by running `scripts/gen_changelog`.
+- Commit and push the release branch.
+- Create a pull request from release branch to master with the upcoming release number as the title. Put the changes for the new release from the updated changelog as the PR message.
+- Merge the pull request into master, do not squash.
+- Go to github releases and tag a new release on the master branch. Use the description from the merged PR.
+- Fetch and checkout the master branch.
+- Fetch and checkout the develop branch.
+- Merge master into develop.
+- Update version in `const.py`to the new develop version number, eg `'0.3.0.dev0'`
+- Commit the version bump and push to develop branch.

--- a/camacq/const.py
+++ b/camacq/const.py
@@ -1,5 +1,8 @@
 """Store common constants."""
-__version__ = '0.4.0.dev0'
+MAJOR_VERSION = 0
+MINOR_VERSION = 4
+PATCH_VERSION = '0.dev0'
+__version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 
 CONFIG_DIR = 'config_dir'
 COORD_FILE = 'coord_file'

--- a/scripts/gen_changelog
+++ b/scripts/gen_changelog
@@ -1,0 +1,46 @@
+#!/bin/sh
+if ! gem list github_changelog_generator -i; then
+  echo "github_changelog_generator must be installed before running this \
+script.\nInstall with (requires Ruby):\ngem install \
+github_changelog_generator\n\nMake sure you set a github access token \
+to avoid the GitHub API rate limit.";
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+head -n 4 camacq/const.py | tail -n 1 | grep PATCH_VERSION > /dev/null
+if [ $? -eq 1 ]
+then
+  echo "Patch version not found on const.py line 4"
+  exit 1
+fi
+PATCH_VERSION=$(head -n 4 camacq/const.py | tail -n 1 | grep PATCH_VERSION)
+
+head -n 4 camacq/const.py | tail -n 1 | grep dev > /dev/null
+if [ $? -eq 0 ]
+then
+  echo "Release version should not contain dev tag"
+  exit 1
+fi
+
+head -n 3 camacq/const.py | tail -n 1 | grep MINOR_VERSION > /dev/null
+if [ $? -eq 1 ]
+then
+  echo "Minor version not found on const.py line 3"
+  exit 1
+fi
+MINOR_VERSION=$(head -n 3 camacq/const.py | tail -n 1 | grep MINOR_VERSION)
+
+head -n 2 camacq/const.py | tail -n 1 | grep MAJOR_VERSION > /dev/null
+if [ $? -eq 1 ]
+then
+  echo "Major version not found on const.py line 2"
+  exit 1
+fi
+MAJOR_VERSION=$(head -n 2 camacq/const.py | tail -n 1 | grep MAJOR_VERSION)
+
+VERSION="$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION"
+
+github_changelog_generator -u CellProfiling -p cam_acq \
+  --issue-line-labels "breaking change" --future-release $VERSION


### PR DESCRIPTION
* Break out major, minor and patch version numbers.
* Add script to generate change log during release.
* Script depends on github-changelog-generator.
* Add release instructions.