### PR TITLE
Refactor and clean up event bus

### DIFF
--- a/camacq/config.py
+++ b/camacq/config.py
@@ -125,8 +125,9 @@ def ensure_config_exists(config_dir):
     config_path = find_config_file(config_dir)
 
     if config_path is None:
-        print("Unable to find configuration. Creating default one in",
-              config_dir)
+        print(
+            'Unable to find configuration. Creating default one in',
+            config_dir)
         config_path = create_default_config(config_dir)
 
     return config_path

--- a/camacq/control.py
+++ b/camacq/control.py
@@ -97,6 +97,10 @@ class Center(object):
         self.exit_code = 0
         self.threads = []
 
+    def __repr__(self):
+        """Return the representation."""
+        return "<Center: config: {}>".format(self.config)
+
     @property
     def finished(self):
         """:bool: Return True if handlers are registered on the bus."""

--- a/camacq/control.py
+++ b/camacq/control.py
@@ -103,8 +103,8 @@ class Center(object):
 
     @property
     def finished(self):
-        """:bool: Return True if handlers are registered on the bus."""
-        return not self.bus.handlers
+        """:bool: Return True if nothing is registered on the bus."""
+        return not self.bus.event_types
 
     def end(self, code):
         """Prepare app for exit.

--- a/camacq/data/__init__.py
+++ b/camacq/data/__init__.py
@@ -1,1 +1,1 @@
-"""Store not python files."""
+"""Store non python files."""

--- a/camacq/event.py
+++ b/camacq/event.py
@@ -231,9 +231,9 @@ class EventBus(object):
         self._registry = defaultdict(list)
 
     @property
-    def handlers(self):
-        """:list: Return all registered handlers."""
-        return [handler for handler in self._registry]
+    def event_types(self):
+        """:list: Return all registered event types."""
+        return [event_type for event_type in self._registry]
 
     def _register_handler(self, event_class, handler):
         """Register handler to fire for events of type event_class."""

--- a/camacq/event.py
+++ b/camacq/event.py
@@ -277,6 +277,7 @@ class EventBus(object):
             An instance of Event or an instance of subclass of Event.
         """
         _LOGGER.debug(event)
+        # Inspired by https://goo.gl/VEPG3n
         for event_class in event.__class__.__mro__:
             for handler in self._registry.get(event_class, []):
                 handler(event)

--- a/camacq/event.py
+++ b/camacq/event.py
@@ -1,7 +1,7 @@
 """Hold events."""
 import logging
+from collections import defaultdict
 from functools import partial
-from importlib import import_module
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -216,17 +216,6 @@ class CamAcqStopEvent(Event):
         return self.data.get('exit_code')
 
 
-class DummyEvent(Event):
-    """Represent a dummy event."""
-
-    __slots__ = ()
-
-
-def dummy_handler(event):
-    """Handle dummy event."""
-    pass
-
-
 class EventBus(object):
     """Representation of an eventbus.
 
@@ -239,18 +228,16 @@ class EventBus(object):
     def __init__(self, center):
         """Set up instance."""
         self._center = center
-        self._event = import_module('zope.event')
-        self._handler = import_module('zope.event.classhandler')
-        # Limitation in zope requires at least one item in registry to
-        # avoid adding another dispatch function to the list of
-        # subscribers.
-        self._handler.handler(DummyEvent, dummy_handler)
+        self._registry = defaultdict(list)
 
     @property
     def handlers(self):
         """:list: Return all registered handlers."""
-        return [handler for handler in self._handler.registry
-                if not isinstance(handler, DummyEvent)]
+        return [handler for handler in self._registry]
+
+    def _register_handler(self, event_class, handler):
+        """Register handler to fire for events of type event_class."""
+        self._registry[event_class].append(handler)
 
     def register(self, event_type, handler):
         """Register event handler and return a function to remove it.
@@ -273,20 +260,13 @@ class EventBus(object):
             Return a function to remove the registered handler.
         """
         handler = partial(handler, self._center)
-        self._handler.handler(event_type, handler)
+        self._register_handler(event_type, handler)
 
         def remove():
             """Remove registered event handler."""
-            self._handler.registry.pop(event_type, None)
+            self._registry.pop(event_type, None)
 
         return remove
-
-    def _clear(self):
-        """Remove all registered handlers except dummy."""
-        for handler in self._handler.registry:
-            if isinstance(handler, DummyEvent):
-                continue
-            self._handler.registry.pop(handler, None)
 
     def notify(self, event):
         """Notify handlers that an event has fired.
@@ -297,4 +277,6 @@ class EventBus(object):
             An instance of Event or an instance of subclass of Event.
         """
         _LOGGER.debug(event)
-        self._event.notify(event)
+        for event_class in event.__class__.__mro__:
+            for handler in self._registry.get(event_class, []):
+                handler(event)

--- a/camacq/helper.py
+++ b/camacq/helper.py
@@ -71,7 +71,10 @@ def _deep_conf_access(config, key_list):
     """Return value in nested dict using keys in key_list."""
     val = config
     for key in key_list:
-        val = val[key]
+        _val = val.get(key)
+        if _val is None:
+            return val
+        val = _val
     return val
 
 
@@ -106,10 +109,12 @@ def setup_all_modules(center, config, package_path, **kwargs):
             name for name in imported_pkg.__name__.split('.')
             if name != PACKAGE]
         pkg_config = _deep_conf_access(config, keys)
-        if module.__name__ in pkg_config:
+        if module.__name__.split('.')[-1] in pkg_config:
             if is_pkg and hasattr(module, 'setup_package'):
+                _LOGGER.info('Setting up %s', module.__name__)
                 module.setup_package(center, config, **kwargs)
             elif hasattr(module, 'setup_module'):
+                _LOGGER.info('Setting up %s', module.__name__)
                 module.setup_module(center, config, **kwargs)
 
 

--- a/camacq/helper.py
+++ b/camacq/helper.py
@@ -104,7 +104,7 @@ def setup_all_modules(center, config, package_path, **kwargs):
         else:
             module = loader.find_module(name).load_module(name)
             _MODULE_CACHE[name] = module
-        _LOGGER.info('Loaded %s', name)
+        _LOGGER.debug('Loaded %s', name)
         keys = [
             name for name in imported_pkg.__name__.split('.')
             if name != PACKAGE]

--- a/camacq/helper.py
+++ b/camacq/helper.py
@@ -95,14 +95,14 @@ def setup_all_modules(center, config, package_path, **kwargs):
     """
     imported_pkg = import_module(package_path)
     # yields, non recursively, modules under package_path
-    for loader, name, is_pkg in pkgutil.iter_modules(
+    for _, name, is_pkg in pkgutil.iter_modules(
             imported_pkg.__path__, prefix='{}.'.format(imported_pkg.__name__)):
         if 'main' in name:
             continue
         if name in _MODULE_CACHE:
             module = _MODULE_CACHE[name]
         else:
-            module = loader.find_module(name).load_module(name)
+            module = import_module(name)
             _MODULE_CACHE[name] = module
         _LOGGER.debug('Loaded %s', name)
         keys = [
@@ -111,10 +111,10 @@ def setup_all_modules(center, config, package_path, **kwargs):
         pkg_config = _deep_conf_access(config, keys)
         if module.__name__.split('.')[-1] in pkg_config:
             if is_pkg and hasattr(module, 'setup_package'):
-                _LOGGER.info('Setting up %s', module.__name__)
+                _LOGGER.info('Setting up %s package', module.__name__)
                 module.setup_package(center, config, **kwargs)
             elif hasattr(module, 'setup_module'):
-                _LOGGER.info('Setting up %s', module.__name__)
+                _LOGGER.info('Setting up %s module', module.__name__)
                 module.setup_module(center, config, **kwargs)
 
 

--- a/camacq/sample.py
+++ b/camacq/sample.py
@@ -326,6 +326,7 @@ class Sample(object):
 
     def _set_image_on_event(self, center, event):
         """Set sample image on an image event from a microscope API."""
+        print('Inside handler: ', event)
         self.set_image(
             event.path, channel_id=event.channel_id, field_x=event.field_x,
             field_y=event.field_y, well_x=event.well_x, well_y=event.well_y)

--- a/camacq/sample.py
+++ b/camacq/sample.py
@@ -11,6 +11,11 @@ from camacq.image import Image
 _LOGGER = logging.getLogger(__name__)
 
 
+def setup_module(center, config):
+    """Set up sample module."""
+    _LOGGER.info('Setting up sample')
+
+
 class Channel(object):
     """A channel with gain.
 

--- a/camacq/sample.py
+++ b/camacq/sample.py
@@ -326,7 +326,6 @@ class Sample(object):
 
     def _set_image_on_event(self, center, event):
         """Set sample image on an image event from a microscope API."""
-        print('Inside handler: ', event)
         self.set_image(
             event.path, channel_id=event.channel_id, field_x=event.field_x,
             field_y=event.field_y, well_x=event.well_x, well_y=event.well_y)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,11 @@
---index-url https://pypi.python.org/simple/
-colorlog >= 2.10.0
-jinja2 >= 2.8
-matplotlib >= 2.0.0
+colorlog >= 3.1.0
+jinja2 >= 2.10
+matplotlib >= 2.1.1
 matrixscreener >= 0.6.1
-numpy >= 1.13.3
-pandas >= 0.20.1
-Pillow >= 2.9.0
-PyYAML >= 3.11
+numpy >= 1.14.0
+pandas >= 0.22.0
+Pillow >= 5.0.0
+PyYAML >= 3.12
 ruamel.yaml == 0.13.14
-scipy >= 0.19.0
-tifffile >= 0.7.0
-zope.event >= 4.2.0
+scipy >= 1.0.0
+tifffile >= 0.13.0

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
-sphinx>=1.6.5
+sphinx>=1.6.6
 sphinx-autobuild>=0.7.1
 sphinx_rtd_theme>=0.2.4

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -4,7 +4,7 @@ mock>=2.0.0
 pycodestyle>=2.3.1
 pydocstyle==1.1.1
 pylint==1.6.5
-pytest>=3.2.5
-pytest-cov>=2.4.0
+pytest>=3.3.2
+pytest-cov>=2.5.1
 pytest-mock>=1.6.0
 pytest-timeout>=1.2.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -6,5 +6,5 @@ pydocstyle==1.1.1
 pylint==1.6.5
 pytest>=3.3.2
 pytest-cov>=2.5.1
-pytest-mock>=1.6.0
-pytest-timeout>=1.2.0
+pytest-mock>=1.6.3
+pytest-timeout>=1.2.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,7 @@
 """Set up common fixtures and helpers for pytest."""
 import pytest
-from pkg_resources import resource_filename
 
 from camacq.control import Center
-from camacq.config import load_config_file, DEFAULT_CONFIG_TEMPLATE
-
-
-@pytest.fixture
-def config():
-    """Give access to config via fixture."""
-    min_config_template = resource_filename('camacq', DEFAULT_CONFIG_TEMPLATE)
-    conf = load_config_file(min_config_template)
-    yield conf
 
 
 @pytest.fixture
@@ -20,14 +10,3 @@ def center():
     _center = Center({})
     yield _center
     _center.end(0)
-    clear_event_registry(_center)
-
-
-def clear_event_registry(center_obj):
-    """Clear event registry.
-
-    Run this between tests.
-    """
-    # pylint: disable=protected-access
-    del center_obj.bus._event.subscribers[:]
-    center_obj.bus._handler.registry.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,14 @@ def center():
     _center = Center({})
     yield _center
     _center.end(0)
+    clear_event_registry(_center)
+
+
+def clear_event_registry(center_obj):
+    """Clear event registry.
+
+    Run this between tests.
+    """
+    # pylint: disable=protected-access
+    del center_obj.bus._event.subscribers[:]
+    center_obj.bus._handler.registry.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Set up common fixtures and helpers for pytest."""
+import pytest
+from pkg_resources import resource_filename
+
+from camacq.control import Center
+from camacq.config import load_config_file, DEFAULT_CONFIG_TEMPLATE
+
+
+@pytest.fixture
+def config():
+    """Give access to config via fixture."""
+    min_config_template = resource_filename('camacq', DEFAULT_CONFIG_TEMPLATE)
+    conf = load_config_file(min_config_template)
+    yield conf
+
+
+@pytest.fixture
+def center():
+    """Give access to center via fixture."""
+    _center = Center({})
+    yield _center
+    _center.end(0)

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for plugins."""

--- a/tests/plugins/test_gain.py
+++ b/tests/plugins/test_gain.py
@@ -14,8 +14,8 @@ from camacq.control import Center
 from camacq.image import make_proj
 from camacq.plugins.gain import calc_gain
 
-GAIN_DATA_DIR = os.path.join(
-    os.path.dirname(__file__), '../tests/fixtures/gain_data')
+GAIN_DATA_DIR = os.path.normpath(os.path.join(
+    os.path.dirname(__file__), '../fixtures/gain_data'))
 WELL_NAME = 'U01--V00'
 FULL_WELL_NAME = 'chamber--{}'.format(WELL_NAME)
 WELL_PATH = os.path.join(GAIN_DATA_DIR, 'slide', FULL_WELL_NAME)

--- a/tests/plugins/test_gain.py
+++ b/tests/plugins/test_gain.py
@@ -1,16 +1,13 @@
 """Test gain calculation."""
 import os
 import pprint
-from mock import patch
 
 import pytest
-from pkg_resources import resource_filename
+from mock import patch
 
 from camacq.api.leica import LeicaImageEvent
 from camacq.api.leica.helper import get_imgs
-from camacq.config import DEFAULT_CONFIG_TEMPLATE, load_config_file
 from camacq.const import IMAGING_DIR, JOB_ID
-from camacq.control import Center
 from camacq.image import make_proj
 from camacq.plugins.gain import calc_gain
 
@@ -24,12 +21,6 @@ IMAGE_PATH = os.path.join(
     'field--X00--Y00/image--U01--V00--E02--X00--Y00--Z00--C00.ome.tif')
 
 
-class MockImageEvent(LeicaImageEvent):
-    """Mock ImageEvent."""
-
-    __slots__ = ()
-
-
 @pytest.fixture
 def mock_os_path():
     """Patch nt path with os path."""
@@ -38,18 +29,17 @@ def mock_os_path():
         yield _mock
 
 
-def test_gain(mock_os_path):
+# @pytest.mark.skip(reason="disable test while debugging issue with center")
+def test_gain(center, mock_os_path):
     """Run gain calculation test."""
     # pylint: disable=redefined-outer-name
     images = get_imgs(WELL_PATH, search=JOB_ID.format(2))
-    default_config_template = resource_filename(
-        'camacq', DEFAULT_CONFIG_TEMPLATE)
-    config = load_config_file(default_config_template)
+    config = {'plugins': {'gain': {'objective': 'end_63x'}}}
     config[IMAGING_DIR] = GAIN_DATA_DIR
     pprint.pprint(config)
-    center = Center(config)
+    center.config = config
     for path in images:
-        center.bus.notify(MockImageEvent({'path': path}))
+        center.bus.notify(LeicaImageEvent({'path': path}))
     projs = make_proj(center.sample, images)
     save_path = os.path.join(WELL_PATH, WELL_NAME)
     gain_dict = calc_gain(center, save_path, projs, plot=False)

--- a/tests/plugins/test_gain.py
+++ b/tests/plugins/test_gain.py
@@ -29,7 +29,6 @@ def mock_os_path():
         yield _mock
 
 
-# @pytest.mark.skip(reason="disable test while debugging issue with center")
 def test_gain(center, mock_os_path):
     """Run gain calculation test."""
     # pylint: disable=redefined-outer-name

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,30 @@
+"""Test the event bus."""
+from camacq import event as event_mod
+
+
+def test_event_bus(center):
+    """Test register handler, fire event and remove handler."""
+    event = event_mod.Event({'test': 2})
+    bus = event_mod.EventBus(center)
+
+    def handler(center, event):
+        """Handle event."""
+        if 'test' not in center.data:
+            center.data['test'] = 0
+        center.data['test'] += event.data['test']
+
+    assert not bus.event_types
+
+    remove = bus.register(event_mod.Event, handler)
+
+    assert bus.event_types == [event_mod.Event]
+    assert not center.data
+
+    bus.notify(event)
+
+    assert center.data.get('test') == 2
+
+    remove()
+    bus.notify(event)
+
+    assert center.data.get('test') == 2

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,0 +1,10 @@
+"""Test helper module."""
+from camacq import helper
+
+
+def test_setup_modules(center, caplog):
+    """Test setup_all_modules."""
+    config = {'sample': None}
+    helper.setup_all_modules(center, config, 'camacq')
+    assert 'Setting up sample' in caplog.text
+    assert 'Setting up camacq.sample' in caplog.text

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,7 +1,10 @@
 """Test helper module."""
+import pytest
+
 from camacq import helper
 
 
+# @pytest.mark.skip(reason="disable test while debugging issue with fixtures")
 def test_setup_modules(center, caplog):
     """Test setup_all_modules."""
     config = {'sample': None}

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -4,7 +4,7 @@ import pytest
 from camacq import helper
 
 
-# @pytest.mark.skip(reason="disable test while debugging issue with fixtures")
+# @pytest.mark.skip(reason="disable test while debugging issue with center")
 def test_setup_modules(center, caplog):
     """Test setup_all_modules."""
     config = {'sample': None}

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,13 +1,28 @@
 """Test helper module."""
-import pytest
-
 from camacq import helper
 
 
-@pytest.mark.skip(reason="disable test while debugging issue with center")
-def test_setup_modules(center, caplog):
+def test_setup_modules_api(center, caplog):
     """Test setup_all_modules."""
-    config = {'sample': None}
+    config = {'api': {'leica': None}}
+    parent = helper.FeatureParent()
+    helper.setup_all_modules(
+        center, config, 'camacq.api', add_child=parent.add_child)
+    assert 'Setting up camacq.api.leica package' in caplog.text
+    assert 'Connecting to server localhost failed' in caplog.text
+
+
+def test_setup_modules_plugins(center, caplog):
+    """Test setup_all_modules plugins package."""
+    config = {'plugins': {'gain': {}}}
+    helper.setup_all_modules(center, config, 'camacq.plugins')
+    assert 'Setting up camacq.plugins.gain module' in caplog.text
+    assert 'No objective selected' in caplog.text
+
+
+def test_setup_modules_camacq(center, caplog):
+    """Test setup_all_modules camacq package."""
+    config = {'sample': {}}
     helper.setup_all_modules(center, config, 'camacq')
+    assert 'Setting up camacq.sample module' in caplog.text
     assert 'Setting up sample' in caplog.text
-    assert 'Setting up camacq.sample' in caplog.text

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,4 +1,6 @@
 """Test helper module."""
+from mock import patch
+
 from camacq import helper
 
 
@@ -6,10 +8,10 @@ def test_setup_modules_api(center, caplog):
     """Test setup_all_modules."""
     config = {'api': {'leica': None}}
     parent = helper.FeatureParent()
-    helper.setup_all_modules(
-        center, config, 'camacq.api', add_child=parent.add_child)
+    with patch('camacq.api.leica.CAM'):
+        helper.setup_all_modules(
+            center, config, 'camacq.api', add_child=parent.add_child)
     assert 'Setting up camacq.api.leica package' in caplog.text
-    assert 'Connecting to server localhost failed' in caplog.text
 
 
 def test_setup_modules_plugins(center, caplog):

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -4,7 +4,7 @@ import pytest
 from camacq import helper
 
 
-# @pytest.mark.skip(reason="disable test while debugging issue with center")
+@pytest.mark.skip(reason="disable test while debugging issue with center")
 def test_setup_modules(center, caplog):
     """Test setup_all_modules."""
     config = {'sample': None}


### PR DESCRIPTION
* Refactor event bus. Remove dependency on zope.events. It had a bug and the structure didn't fit our use case.
* Attribute idea of class MRO lookup to zope.events.
* Add test and fix bug in helper.
* Add tests plugins package and move gain test.
* Update requirements pypi packages.
* Add tests and package level fixture.