### PR TITLE
Add condition to automations

### DIFF
--- a/camacq/api/__init__.py
+++ b/camacq/api/__init__.py
@@ -5,8 +5,8 @@ from camacq.event import Event
 from camacq.helper import FeatureParent, setup_all_modules
 
 ACTION_SEND = 'send'
-ACTION_START_IMAGING = 'start_imaging',
-ACTION_STOP_IMAGING = 'stop_imaging',
+ACTION_START_IMAGING = 'start_imaging'
+ACTION_STOP_IMAGING = 'stop_imaging'
 
 ACTION_TO_METHOD = {
     ACTION_SEND: 'send',

--- a/camacq/api/leica/helper.py
+++ b/camacq/api/leica/helper.py
@@ -25,7 +25,7 @@ def find_image_path(relpath, root):
         Return path to image.
     """
     if not relpath:
-        return
+        return None
     paths = []
     while relpath:
         relpath, tail = ntpath.split(relpath)

--- a/camacq/data/config.yml
+++ b/camacq/data/config.yml
@@ -78,7 +78,7 @@ automations:
     condition:
       type: AND
       conditions:
-        - "{{ not trigger.event.well.images }}"
+        - condition: "{{ not trigger.event.well.images }}"
     action:
       - type: command
         id: send
@@ -110,9 +110,11 @@ automations:
       - type: plugin
         id: calc_gain
         data:
+          # FIXME: fix the template.
           images: >
-            {{ sample.images(
-              trigger.event.image.well_x, trigger.event.image.well_y) }}
+            {% for path, image in sample.images.items() %}
+              (
+              trigger.event.well_x, trigger.event.well_y) }}
   - name: set_exp_gain
     trigger:
       - type: event
@@ -132,37 +134,26 @@ automations:
   - name: add_exp_job
     trigger:
       - type: event
-        id: command_event
-        data:
-          id: send
+        id: channel_event
     condition:
       type: AND
       conditions:
-        - "{{ '/cmd:adjust /tar:pmt' in trigger.event.command }}"
-        - >
-          {% for well in sample %}
-            {% if not well.channels %}
-              true
-            {% elif well.channels | length == 4 %}
+        - condition: >
+            {% if trigger.event.well.channels | length == 4 %}
               true
             {% else %}
               false
             {% endif %}
-          {% endfor %}
     action:
       - type: command
         id: send
         data:
-          # add exp job for sample state wells that are not done
           command: >
-            {% for well in sample.wells %}
-              {% if not well_is_done(well.name) %}
-                {% for field in well.fields %}
-                  /cmd:add /tar:camlist /exp:exp_job /ext:af /slide:0
-                  /wellx:well.x /welly:well.y /fieldx:field.x
-                  /fieldy:field.y /dxpos:0 /dypos:0
-                {% endfor %}
-              {% endif %}
+            {% for field in trigger.event.well.fields %}
+              /cmd:add /tar:camlist /exp:exp_job /ext:af /slide:0
+              /wellx:{{ trigger.event.well.x }}
+              /welly:{{ trigger.event.well.y }} /fieldx:{{ field.x }}
+              /fieldy:{{ field.y }} /dxpos:0 /dypos:0
             {% endfor %}
       - type: command
         id: start_scan

--- a/camacq/event.py
+++ b/camacq/event.py
@@ -154,7 +154,7 @@ class ChannelEvent(WellEvent):
 
 
 class SampleImageEvent(Event):
-    """An event produced by a sample image removed event."""
+    """An event produced by a sample image event."""
 
     __slots__ = ()
 

--- a/camacq/image.py
+++ b/camacq/image.py
@@ -91,6 +91,7 @@ def make_proj(sample, path_list):
         if not image:
             continue
         # Exclude images with 0, 16 or 256 pixel side.
+        # pylint: disable=len-as-condition
         if (len(image.data) == 0 or len(image.data) == 16 or
                 len(image.data) == 256):
             continue

--- a/camacq/log.py
+++ b/camacq/log.py
@@ -28,10 +28,9 @@ def check_path(path):
     if os.path.isfile(path) and os.access(path, os.W_OK) or \
        not os.path.isfile(path) and os.access(os.path.dirname(path), os.W_OK):
         return True
-    else:
-        _LOGGER.error(
-            'Unable to access log file %s (access denied)', path)
-        return False
+    _LOGGER.error(
+        'Unable to access log file %s (access denied)', path)
+    return False
 
 
 def enable_log(config):

--- a/camacq/plugins/gain.py
+++ b/camacq/plugins/gain.py
@@ -607,6 +607,7 @@ def send_com_and_start(center, commands, stop_data, handler):
         """Test if stop should be done."""
         if all(test in event.rel_path for test in stop_data):
             return True
+        return False
 
     remove_listener = center.bus.register(
         ImageEvent, handler_factory(center, handler, stop_test))

--- a/camacq/sample.py
+++ b/camacq/sample.py
@@ -470,7 +470,7 @@ class Sample(object):
         """
         plate = self.get_plate(plate_name)
         if not plate:
-            return
+            return None
         well = plate.set_well(well_x, well_y)
         event = WellEvent({'sample': self, 'plate': plate, 'well': well})
         self._bus.notify(event)

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -3,7 +3,7 @@ flake8==3.5.0
 mock>=2.0.0
 pycodestyle>=2.3.1
 pydocstyle==1.1.1
-pylint==1.6.5
+pylint==1.8.2
 pytest>=3.3.2
 pytest-cov>=2.5.1
 pytest-mock>=1.6.3

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,6 +26,7 @@ def image_event(data):
     """Send a reply about saved image."""
     if 'startcamscan' in data.decode():
         return tuples_as_bytes(CAM_REPLY.pop())
+    return None
 
 
 class EchoServer(object):


### PR DESCRIPTION
An automation with a condition can look like this:

```yaml
automations:
  - name: image_next_well
    trigger:
      - type: event
        id: well_event
    condition:
      type: AND
      conditions:
        - condition: "{{ not trigger.event.well.images }}"
    action:
      - type: command
        id: start_scan
```

Here we want to start scan upon a well event, if that well doesn't have any images already acquired.

It's also possible to nest conditions and specify AND or OR for how to combine the conditions.

```yaml
condition:
  type: AND
  conditions:
    - condition: >
       {% if 'test' in trigger.event.data %}true
       {% endif %}
    - type: OR
      conditions:
        - condition: >
            {% if trigger.event.data.test == 1 %}true
            {% endif %}
        - condition: >
            {% if trigger.event.data.test == 2 %}true
            {% endif %}
```
A condition must always evaluate to either true or false in the template.

* Update default config. Some things needs to be fixed later in the gain automations. Added fixmes for these.
* Add tests.
* Fix lint issues.

Fixes #50