### PR TITLE
Separate image data from sample images

### DIFF
--- a/camacq/image.py
+++ b/camacq/image.py
@@ -90,21 +90,22 @@ def make_proj(sample, path_list):
         image = sample.get_image(path)
         if not image:
             continue
+        channel = image.channel_id
+        image = ImageData(path=image.path)
         # Exclude images with 0, 16 or 256 pixel side.
         # pylint: disable=len-as-condition
         if (len(image.data) == 0 or len(image.data) == 16 or
                 len(image.data) == 256):
             continue
-        channel = image.channel_id
         sorted_images[channel].append(image)
         proj = np.max([img.data for img in sorted_images[channel]], axis=0)
-        max_imgs[channel] = Image(
-            path=path, data=proj, metadata=image.metadata, channel_id=channel)
+        max_imgs[channel] = ImageData(
+            path=path, data=proj, metadata=image.metadata)
     return max_imgs
 
 
-class Image(object):
-    """Represent an image with a path, data, metadata and histogram.
+class ImageData(object):
+    """Represent the data of an image with path, data, metadata and histogram.
 
     Parameters
     ----------
@@ -114,48 +115,20 @@ class Image(object):
         A numpy array with the image data.
     metadata : dict
         The meta data of the image as a JSON dict.
-    channel_id : int
-        The channel id of the image.
-    field_x : int
-        The field x coordinate of the image.
-    field_y : int
-        The field y coordinate of the image.
-    well_x : int
-        The well x coordinate of the image.
-    well_y : int
-        The well y coordinate of the image.
 
     Attributes
     ----------
     path : str
         The path to the image.
-    channel_id : int
-        The channel id of the image.
-    field_x : int
-        The field x coordinate of the image.
-    field_y : int
-        The field y coordinate of the image.
-    well_x : int
-        The well x coordinate of the image.
-    well_y : int
-        The well y coordinate of the image.
     """
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes
 
-    def __init__(
-            self, path=None, data=None, metadata=None, channel_id=None,
-            field_x=None, field_y=None, well_x=None, well_y=None, plate=None):
+    def __init__(self, path=None, data=None, metadata=None):
         """Set up instance."""
         self.path = path
         self._data = data
         self._metadata = metadata or {}
-        self.channel_id = channel_id
-        self.field_x = field_x
-        self.field_y = field_y
-        self.well_x = well_x
-        self.well_y = well_y
-        self.plate_name = plate
 
     @property
     def data(self):
@@ -163,8 +136,6 @@ class Image(object):
 
         :setter: Set the data of the image.
         """
-        # pylint: disable=fixme
-        # TODO: Investigate memory consideration of storing image data.
         if self._data is None:
             self._load_image_data()
         return self._data
@@ -232,4 +203,4 @@ class Image(object):
 
     def __repr__(self):
         """Return the representation."""
-        return '<Image(path={0!r})>'.format(self.path)
+        return '<ImageData(path={0!r})>'.format(self.path)

--- a/camacq/plugins/rename_image.py
+++ b/camacq/plugins/rename_image.py
@@ -37,8 +37,8 @@ def setup_module(center, config):
             image = center.sample.get_image(path)
             center.sample.remove_image(path)
             center.sample.set_image(
-                new_name, image.data, image.metadata, image.channel_id,
-                image.field_x, image.field_y, image.well_x, image.well_y)
+                new_name, image.channel_id, image.field_x, image.field_y,
+                image.well_x, image.well_y)
 
     center.actions.register(__name__, ACTION_RENAME_IMAGE, handle_action)
 

--- a/camacq/sample.py
+++ b/camacq/sample.py
@@ -7,7 +7,6 @@ from camacq.api import ImageEvent
 from camacq.const import FIELD_NAME, WELL_NAME
 from camacq.event import (ChannelEvent, FieldEvent, ImageRemovedEvent,
                           PlateEvent, WellEvent)
-from camacq.image import Image
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +48,63 @@ def setup_module(center, config):
 
     for action_id in ACTION_TO_METHOD:
         center.actions.register(__name__, action_id, handle_action)
+
+
+class Image(object):
+    """An image with path and position info.
+
+    Parameters
+    ----------
+    path : str
+        Path to the image.
+    channel_id : int
+        The channel id of the image.
+    field_x : int
+        The field x coordinate of the image.
+    field_y : int
+        The field y coordinate of the image.
+    well_x : int
+        The well x coordinate of the image.
+    well_y : int
+        The well y coordinate of the image.
+
+    Attributes
+    ----------
+    path : str
+        The path to the image.
+    channel_id : int
+        The channel id of the image.
+    field_x : int
+        The field x coordinate of the image.
+    field_y : int
+        The field y coordinate of the image.
+    well_x : int
+        The well x coordinate of the image.
+    well_y : int
+        The well y coordinate of the image.
+    """
+
+    # pylint: disable=too-many-arguments, too-few-public-methods
+
+    __slots__ = (
+        'path', 'channel_id', 'field_x', 'field_y', 'well_x', 'well_y',
+        'plate_name')
+
+    def __init__(
+            self, path=None, channel_id=None, field_x=None, field_y=None,
+            well_x=None, well_y=None, plate=None):
+        """Set up instance."""
+        self.path = path
+        self.channel_id = channel_id
+        self.field_x = field_x
+        self.field_y = field_y
+        self.well_x = well_x
+        self.well_y = well_y
+        self.plate_name = plate
+
+    def __repr__(self):
+        """Return the representation."""
+        return '<Image(path={0!r})>'.format(self.path)
 
 
 class Channel(object):
@@ -623,19 +679,14 @@ class Sample(object):
         return self._images.get(path)
 
     def set_image(
-            self, path, data=None, metadata=None, channel_id=None,
-            field_x=None, field_y=None, well_x=None, well_y=None,
-            plate_name=None):
+            self, path, channel_id=None, field_x=None, field_y=None,
+            well_x=None, well_y=None, plate_name=None):
         """Add an image to the sample.
 
         Parameters
         ----------
         path : str
             Path to the image.
-        data : numpy array
-            A numpy array with the image data.
-        metadata : str
-            The meta data of the image.
         channel_id : int
             The channel id of the image.
         field_x : int
@@ -651,8 +702,7 @@ class Sample(object):
         """
         # pylint: disable=too-many-arguments, too-many-locals
         image = Image(
-            path, data, metadata, channel_id, field_x, field_y, well_x, well_y,
-            plate_name)
+            path, channel_id, field_x, field_y, well_x, well_y, plate_name)
         self._images[image.path] = image
 
         if plate_name is not None:


### PR DESCRIPTION
* Only store image path and position info in sample images.
* Have a separate ImageData class to handle image data and metadata.
* This avoids automatically using a lot of memory from image data in the sample instance.