### PR TITLE
Fire sample image event when sample image changes

### DIFF
--- a/camacq/sample.py
+++ b/camacq/sample.py
@@ -750,6 +750,8 @@ class Sample(object):
             path, channel_id, field_x, field_y, well_x, well_y, plate_name)
         self._images[image.path] = image
 
+        self._bus.notify(SampleImageEvent({'image': image}))
+
         if plate_name is not None:
             plate = self.get_plate(plate_name)
             if not plate:


### PR DESCRIPTION
- Fire both api image events and sample image events.
- API image event only fires when new images are acquired.
- Sample image event fires whenever an image changes state.

fixes #66 