### PR TITLE
Refactor to use asyncio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 cache: pip
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 sudo: false

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Python project to control microscope through client-server program.
 
 Install
 -------
-- Install the camacq package. Python 2.7, 3.5 and 3.6 are supported.
+- Install the camacq package. 3.5 and 3.6 are supported.
 
 ::
 

--- a/camacq/automations/event.py
+++ b/camacq/automations/event.py
@@ -15,13 +15,13 @@ def handle_trigger(center, config, trigger_func):
     event_type = config[CONF_ID]
     event_data = config.get(CONF_EVENT_DATA)
 
-    def handle_event(center, event):
+    async def handle_event(center, event):
         """Listen for events and call trigger when data matches."""
         if not event_data or all(
                 val == getattr(event, key, None)
                 for key, val in event_data.items()):
             # pass variables from trigger with event
-            trigger_func({
+            await trigger_func({
                 CONF_TRIGGER: {
                     CONF_TYPE: CONF_EVENT,
                     ATTR_EVENT: event}})

--- a/camacq/const.py
+++ b/camacq/const.py
@@ -4,6 +4,7 @@ MINOR_VERSION = 4
 PATCH_VERSION = '0.dev0'
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 
+ACTION_TIMEOUT = 60.0
 CONF_DATA = 'data'
 CONF_ID = 'id'
 CONF_TRIGGER = 'trigger'

--- a/camacq/event.py
+++ b/camacq/event.py
@@ -2,7 +2,6 @@
 import logging
 from builtins import object  # pylint: disable=redefined-builtin
 from collections import defaultdict
-from functools import partial
 
 from camacq.const import BASE_EVENT
 
@@ -71,7 +70,7 @@ class EventBus(object):
         event_type : str
             A string representing the type of event.
         handler : callable
-            A function that should accept two parameters, center and
+            A coroutine function that should accept two parameters, center and
             event. The first parameter is the Center instance, the
             second parameter is the Event instance that has fired.
 
@@ -82,7 +81,6 @@ class EventBus(object):
         """
         _LOGGER.debug(
             'Registering event handler for event type %s', event_type)
-        handler = partial(handler, self._center)
         self._register_handler(event_type, handler)
 
         def remove():
@@ -113,4 +111,4 @@ class EventBus(object):
                     event_class.__name__ == 'newobject'):
                 continue
             for handler in registry.get(event_class.event_type, []):
-                self._center.add_job(handler, event)
+                self._center.create_task(handler(self._center, event))

--- a/camacq/plugins/__init__.py
+++ b/camacq/plugins/__init__.py
@@ -2,7 +2,7 @@
 from camacq.helper import setup_all_modules
 
 
-def setup_package(center, config):
+async def setup_package(center, config):
     """Set up the plugins package.
 
     Parameters
@@ -12,4 +12,4 @@ def setup_package(center, config):
     config : dict
         The config dict.
     """
-    setup_all_modules(center, config, __name__)
+    await setup_all_modules(center, config, __name__)

--- a/camacq/plugins/rename_image.py
+++ b/camacq/plugins/rename_image.py
@@ -15,7 +15,7 @@ RENAME_IMAGE_ACTION_SCHEMA = BASE_ACTION_SCHEMA.extend({
 })
 
 
-def setup_module(center, config):
+async def setup_module(center, config):
     """Set up image rename plugin.
 
     Parameters
@@ -25,7 +25,7 @@ def setup_module(center, config):
     config : dict
         The config dict.
     """
-    def handle_action(**kwargs):
+    async def handle_action(**kwargs):
         """Handle the action call to rename an image.
 
         Parameters
@@ -43,7 +43,8 @@ def setup_module(center, config):
             new_path = os.path.join(old_dir, new_name)
         if not new_path:
             return
-        result = rename_image(old_path, new_path)
+        result = await center.add_executor_job(
+            rename_image, old_path, new_path)
         if not result:
             return
         image = center.sample.get_image(old_path)

--- a/camacq/util.py
+++ b/camacq/util.py
@@ -1,0 +1,77 @@
+"""Host utils that are not aware of the implementation of camacq."""
+import asyncio
+import csv
+import os
+from collections import defaultdict
+
+try:
+    asyncio_run = asyncio.run  # pylint: disable=invalid-name
+except AttributeError:
+
+    def asyncio_run(main, debug=False):
+        """Mimic asyncio.run which is only in Python 3.7."""
+        loop = asyncio.get_event_loop()
+        loop.set_debug(debug)
+        try:
+            return loop.run_until_complete(main)
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+
+def read_csv(path, index=None):
+    """Read a csv file and return a dict of dicts.
+
+    Parameters
+    ----------
+    path : str
+        Path to csv file.
+    index : str
+        Index can be any of the column headers of the csv file.
+        The column under index will be used as keys in the returned
+        dict. If no index is specified, a list of dicts will be
+        returned instead.
+
+    Returns
+    -------
+    defaultdict(dict)
+        Return a dict of dicts with the contents of the csv file,
+        indicated by the index parameter. Each item in the dict will
+        represent a row, with index as key, of the csv file.
+    """
+    csv_map = defaultdict(dict)
+    if index is None:
+        csv_map = []
+    path = os.path.normpath(path)
+    with open(path) as file_handle:
+        reader = csv.DictReader(file_handle)
+        for row in reader:
+            if index is None:
+                csv_map.append(row)
+            else:
+                key = row.pop(index)
+                csv_map[key].update(row)
+    return csv_map
+
+
+def write_csv(path, csv_map, header):
+    """Write a dict of dicts as a csv file.
+
+    Parameters
+    ----------
+    path : str
+        Path to csv file.
+    csv_map : dict(dict)
+        The dict of dicts that should be written as a csv file.
+    header : list
+        List of strings with the wanted column headers of the csv file.
+        The items in header should correspond to the index key of the
+        primary dict and all the keys of the secondary dict.
+    """
+    with open(path, 'w') as file_handle:
+        writer = csv.DictWriter(file_handle, fieldnames=header)
+        writer.writeheader()
+        for index, cells in csv_map.items():
+            index_dict = {header[0]: index}
+            index_dict.update(cells)
+            writer.writerow(index_dict)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+async_timeout == 3.0.1
 colorlog >= 3.1.2
 future >= 0.16.0
 jinja2 >= 2.10
-leicacam == 0.2.2
+leicacam == 0.3.0
 leicaexperiment >= 0.2.0
 matplotlib >= 2.2.2
 numpy >= 1.14.2

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,12 +1,13 @@
+asynctest==0.12.2
 click==6.7
 flake8==3.5.0
 # pin a minimum working lxml for tox
 lxml >= 4.2.1
-mock==2.0.0
 pycodestyle==2.3.1
 pydocstyle==1.1.1
 pylint==1.8.2
 pytest==3.5.0
+pytest-asyncio==0.9.0
 pytest-cov==2.5.1
 pytest-mock==1.6.3
 pytest-timeout==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIRES = [
     'colorlog',
     'future',
     'jinja2',
-    'leicacam',
+    'leicacam[asyncio]',
     'leicaexperiment',
     'matplotlib',
     'numpy',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from camacq.const import __version__
 
 GITHUB_URL = 'https://github.com/CellProfiling/cam_acq'
 REQUIRES = [
+    'async_timeout',
     'colorlog',
     'future',
     'jinja2',
@@ -72,7 +73,6 @@ CLASSIFIERS = [
 
     # Specify the Python versions you support here. In particular, ensure
     # that you indicate whether you support Python 2, Python 3 or both.
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ from camacq.control import Center
 
 
 @pytest.fixture
-def center():
+def center(event_loop):
     """Give access to center via fixture."""
-    _center = Center({})
+    _center = Center(loop=event_loop)
+    _center._track_tasks = True  # pylint: disable=protected-access
     yield _center
-    _center.end(0)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,67 +1,152 @@
 """Test the control module."""
+import asynctest
+import pytest
+import voluptuous as vol
+
+from camacq.const import CAMACQ_START_EVENT, CAMACQ_STOP_EVENT
+
+# pylint: disable=redefined-outer-name
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio  # pylint: disable=invalid-name
 
 
-def test_job_queue(center):
-    """Test add a job and run a job."""
-    store = []
+async def test_center_start(center):
+    """Test start of Center."""
+    events = []
+    exit_code = 0
 
-    def calc_test(number1, number2):
-        """Add number1 with number2."""
-        return number1 + number2
+    async def handle_event(center, event):
+        """Stop the task that listens to the client socket."""
+        events.append(event)
 
-    def get_result(result):
-        """Store result."""
-        store.append(result)
+    center.bus.register(CAMACQ_START_EVENT, handle_event)
+    center._track_tasks = False  # pylint: disable=protected-access
+    task = center.create_task(center.start())
+    await center.wait_for()
+    await center.end(exit_code)
+    await center.wait_for()
 
-    center.add_job(calc_test, 1, 2, callback=get_result)
-
-    assert not store
-
-    center.run_job()
-
-    assert len(store) == 1
-    assert store[0] == 3
+    assert len(events) == 1
+    assert task.result() == exit_code
 
 
-def test_run_job_without_job(center):
-    """Test run a job without job."""
-    store = []
+async def test_center_end(center):
+    """Test end of Center."""
+    events = []
 
-    def calc_test(number1, number2):
-        """Add number1 with number2."""
-        return number1 + number2
+    async def handle_event(center, event):
+        """Stop the task that listens to the client socket."""
+        events.append(event)
 
-    def get_result(result):
-        """Store result."""
-        store.append(result)
+    center.bus.register(CAMACQ_STOP_EVENT, handle_event)
 
-    center.add_job(calc_test, 1, 2, callback=get_result)
+    await center.end(0)
 
-    assert not store
-    center.run_job()
-    assert len(store) == 1
-    assert store[0] == 3
-    center.run_job()
-    assert len(store) == 1
+    assert len(events) == 1
+    assert events[0].exit_code == 0
 
 
-def test_add_job_without_args(center):
-    """Test add a job without args and run the job."""
-    store = []
+async def test_add_executor_job(center):
+    """Test create task."""
+    def exec_fun(one, two):
+        """Test executor function."""
+        return one + two
 
-    def return_test():
-        """Add number1 with number2."""
-        return 10
+    result = await center.add_executor_job(exec_fun, 1, 2)
 
-    def get_result(result):
-        """Store result."""
-        store.append(result)
+    assert result == 3
 
-    center.add_job(return_test, callback=get_result)
 
-    assert not store
+async def test_create_task(center):
+    """Test create task."""
+    coro_fun = asynctest.CoroutineMock()
+    task = center.create_task(coro_fun())
+    await task
 
-    center.run_job()
+    assert coro_fun.awaited
+    assert task.done()
 
-    assert len(store) == 1
-    assert store[0] == 10
+
+async def test_wait_for(center):
+    """Test wait for tracked tasks."""
+    sec_coro_fun = asynctest.CoroutineMock()
+
+    async def schedule_task(center):
+        """Schedule a new task."""
+        center.create_task(sec_coro_fun())
+
+    task = center.create_task(schedule_task(center))
+    await center.wait_for()
+
+    assert sec_coro_fun.awaited
+    assert task.done()
+
+
+async def test_register_call_action(center):
+    """Test register and call an action."""
+    action_type = 'command'
+    action_id = 'test'
+    result = []
+
+    async def test_action(**kwargs):
+        """Test the action handler."""
+        result.append(kwargs['one'] + kwargs['two'])
+
+    schema = vol.Schema({'one': int, 'two': int})
+    center.actions.register(action_type, action_id, test_action, schema)
+    await center.actions.call(action_type, action_id, one=1, two=2)
+
+    assert len(center.actions.actions) == 1
+    assert action_type in center.actions.actions
+    assert action_id in center.actions.actions[action_type]
+    assert len(result) == 1
+    assert result[0] == 3
+
+
+async def test_register_non_coroutine(center, caplog):
+    """Test register an action with non coroutine function as handler."""
+    action_type = 'command'
+    action_id = 'test'
+
+    def test_action(**kwargs):
+        """Test the action handler as non coroutine function."""
+        pass
+
+    schema = vol.Schema({'one': int, 'two': int})
+    center.actions.register(action_type, action_id, test_action, schema)
+    assert not center.actions.actions
+    assert 'Action handler function {} is not a coroutine function'.format(
+        test_action) in caplog.text
+
+
+async def test_call_non_action(center, caplog):
+    """Test call a non registered action."""
+    action_type = 'command'
+    action_id = 'test'
+
+    await center.actions.call(action_type, action_id)
+
+    assert not center.actions.actions
+    assert 'No action registered for type {} or id {}'.format(
+        action_type, action_id) in caplog.text
+
+
+async def test_call_invalid_args(center, caplog):
+    """Test register and call an action."""
+    action_type = 'command'
+    action_id = 'test'
+    result = []
+
+    async def test_action(**kwargs):
+        """Test the action handler."""
+        result.append(kwargs['one'] + kwargs['two'])
+
+    schema = vol.Schema({'one': int, 'two': int})
+    center.actions.register(action_type, action_id, test_action, schema)
+    await center.actions.call(action_type, action_id, bad=1, two='str')
+
+    assert len(center.actions.actions) == 1
+    assert action_type in center.actions.actions
+    assert action_id in center.actions.actions[action_type]
+    assert not result
+    assert 'Invalid action call parameters' in caplog.text

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,13 +1,18 @@
 """Test the event bus."""
+import pytest
+
 from camacq import event as event_mod
 
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio  # pylint: disable=invalid-name
 
-def test_event_bus(center):
+
+async def test_event_bus(center):
     """Test register handler, fire event and remove handler."""
     event = event_mod.Event({'test': 2})
     bus = center.bus
 
-    def handler(center, event):
+    async def handler(center, event):
         """Handle event."""
         if 'test' not in center.data:
             center.data['test'] = 0
@@ -21,12 +26,12 @@ def test_event_bus(center):
     assert not center.data
 
     bus.notify(event)
-    center.run_all()
+    await center.wait_for()
 
     assert center.data.get('test') == 2
 
     remove()
     bus.notify(event)
-    center.run_all()
+    await center.wait_for()
 
     assert center.data.get('test') == 2

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,39 +1,41 @@
 """Test helper module."""
+import asynctest
 import pytest
-from mock import patch
 
 from camacq import helper
 
 # pylint: disable=redefined-outer-name
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio  # pylint: disable=invalid-name
 
 
 @pytest.fixture
 def mock_leica_setup():
     """Mock setup package."""
-    with patch('camacq.api.leica.setup_package') as mock_setup:
+    with asynctest.patch('camacq.api.leica.setup_package') as mock_setup:
         yield mock_setup
 
 
 @pytest.fixture
 def mock_gain_setup():
     """Mock setup module."""
-    with patch('camacq.plugins.gain.setup_module') as mock_setup:
+    with asynctest.patch('camacq.plugins.gain.setup_module') as mock_setup:
         yield mock_setup
 
 
-def test_setup_modules_package(center, mock_leica_setup):
+async def test_setup_modules_package(center, mock_leica_setup):
     """Test setup_all_modules."""
     config = {'api': {'leica': {}}}
-    helper.setup_all_modules(center, config, 'camacq.api')
+    await helper.setup_all_modules(center, config, 'camacq.api')
     assert len(mock_leica_setup.mock_calls) == 1
     _, args, _ = mock_leica_setup.mock_calls[0]
     assert args == (center, config)
 
 
-def test_setup_modules_module(center, mock_gain_setup):
+async def test_setup_modules_module(center, mock_gain_setup):
     """Test setup_all_modules camacq package."""
     config = {'plugins': {'gain': {}}}
-    helper.setup_all_modules(center, config, 'camacq')
+    await helper.setup_all_modules(center, config, 'camacq')
     assert len(mock_gain_setup.mock_calls) == 1
     _, args, kwargs = mock_gain_setup.mock_calls[0]
     assert args == (center, config)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, lint
+envlist = py35, py36, lint
 skip_missing_interpreters = True
 
 [travis]


### PR DESCRIPTION
* Add .coveragerc file to exclude things.
* Add tests for job queue.
* Add debug log.
* Add notifying events to job queue.
* Clean up api registration.
* Remove not needed functions.
* Fix logging and add thread name.
* Do not include default conf if user conf exists.
* Make sure api dict in data exists.
* Fix thread flow and control.
* Fix delay test.
* Add util module with asyncio.run mimic.
* Convert start and end methods to use asyncio.
* Add signal handling.
* Increase action timeout.
* Update log level of wait and delay message.
* Add tests for control module.
* Drop support for Python 2.7.
* Check if future is done before setting result.
* Enhance action logging.
* Update readme to only mention support Python 3.5+.
* Upgrade leicacam to 0.3.0.
* Clean up test requirements.

closes #92 