### PR TITLE
Add Python 3.8 travis and tox env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: pip
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 install:
   - pip install -U tox-travis
   - pip install -r requirements_tests.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib==3.1.1
 numpy==1.17.3
 pandas==0.25.3
 ruamel.yaml==0.16.5
-scipy==1.3.1
+scipy==1.3.3
 tifffile==2019.7.26
 voluptuous==0.11.7
 xmltodict==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ CLASSIFIERS = [
     # that you indicate whether you support Python 2, Python 3 or both.
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
 ]
 
 CONFIG = {

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, lint, docs
+envlist = py36, py37, py38, lint, docs
 skip_missing_interpreters = True
 
 [travis]
@@ -9,7 +9,7 @@ python =
 
 [testenv]
 commands =
-  pytest -v --timeout=30 --cov=camacq --cov-report= {posargs}
+  pytest --timeout=30 --cov=camacq --cov-report= {posargs}
 deps =
   -rrequirements.txt
   -rrequirements_tests.txt


### PR DESCRIPTION
- Add Python 3.8 tests for travis and tox envs.
- Bump scipy to 1.3.3 to get wheels for Python 3.8.