### PR TITLE
Enable external plugins via entry_points

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ plugins.
 To install a custom plugin, create a Python package with a `setup.py` module that
 implements the entry_points interface with key `"camacq.plugins"`.
 
-```
+```py
 setup(
     ...
     entry_points={"camacq.plugins": "plugin_a = package_a.plugin_a"},
@@ -374,6 +374,14 @@ See the packaging [docs](https://packaging.python.org/guides/creating-and-discov
 
 `camacq` will
 automatically load installed modules or packages that implement this entry_point.
+
+Add a `setup_module` coroutine function in the module or package. This function
+will be awaited with `center` and `config` as arguments.
+
+```py
+async def setup_module(center, config):
+    """Set up the plugin package."""
+```
 
 Plugins have their own configuration section. This is an example of the
 gain plugin section in the configuration.

--- a/README.md
+++ b/README.md
@@ -356,8 +356,24 @@ To extend the functionality of camacq and to make it possible to do
 automated feedback microscopy, camacq supports plugins. A plugin is a
 module or a package in camacq that provides code for a specific task. It
 can eg be an image analysis script. See the
-[documentation](http://cam-acq.readthedocs.io) for all available
+[documentation](http://cam-acq.readthedocs.io) for all default available
 plugins.
+
+To install a custom plugin, create a Python package with a `setup.py` module that
+implements the entry_points interface with key `"camacq.plugins"`.
+
+```
+setup(
+    ...
+    entry_points={"camacq.plugins": "plugin_a = package_a.plugin_a"},
+    ...
+)
+```
+
+See the packaging [docs](https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata) for details.
+
+`camacq` will
+automatically load installed modules or packages that implement this entry_point.
 
 Plugins have their own configuration section. This is an example of the
 gain plugin section in the configuration.

--- a/camacq/api/__init__.py
+++ b/camacq/api/__init__.py
@@ -63,7 +63,7 @@ def register_api(center, api):
     center.data[DATA_API][api.name] = api
 
 
-async def setup_package(center, config):
+async def setup_module(center, config):
     """Set up the microscope API package.
 
     Parameters

--- a/camacq/api/leica/__init__.py
+++ b/camacq/api/leica/__init__.py
@@ -33,7 +33,7 @@ SCAN_FINISHED = "scanfinished"
 SCAN_STARTED = "scanstart"
 
 
-async def setup_package(center, config):
+async def setup_module(center, config):
     """Set up Leica api package.
 
     Parameters

--- a/camacq/automations/__init__.py
+++ b/camacq/automations/__init__.py
@@ -35,7 +35,7 @@ TOGGLE_ACTION_SCHEMA = BASE_ACTION_SCHEMA.extend(
 )
 
 
-async def setup_package(center, config):
+async def setup_module(center, config):
     """Set up automations package.
 
     Parameters

--- a/camacq/helper/__init__.py
+++ b/camacq/helper/__init__.py
@@ -60,7 +60,7 @@ def _deep_conf_access(config, key_list):
     return val
 
 
-async def setup_all_modules(center, config, package_path, **kwargs):
+async def setup_all_modules(center, config, package_path):
     """Set up all modules of a package.
 
     Parameters
@@ -71,9 +71,6 @@ async def setup_all_modules(center, config, package_path, **kwargs):
         The config dict.
     package_path : str
         The path to the package.
-    **kwargs
-        Arbitrary keyword arguments. These will be passed to the
-        setup_module functions.
     """
     imported_pkg = import_module(package_path)
     tasks = []
@@ -89,7 +86,7 @@ async def setup_all_modules(center, config, package_path, **kwargs):
         pkg_config = _deep_conf_access(config, keys)
         module_name = module.__name__.split(".")[-1]
         if module_name in pkg_config and module_name not in CORE_MODULES:
-            task = setup_module(center, config, module, **kwargs)
+            task = setup_one_module(center, config, module)
             if task:
                 tasks.append(task)
 
@@ -97,11 +94,17 @@ async def setup_all_modules(center, config, package_path, **kwargs):
         await asyncio.wait(tasks)
 
 
-def setup_module(center, config, module, **kwargs):
-    """Set up module or package."""
+def setup_one_module(center, config, module):
+    """Set up one module or package.
+
+    Returns
+    -------
+    asyncio.Task
+        Return a task to set up the module or None.
+    """
     if hasattr(module, "setup_module"):
         _LOGGER.info("Setting up %s module", module.__name__)
-        return center.create_task(module.setup_module(center, config, **kwargs))
+        return center.create_task(module.setup_module(center, config))
     return None
 
 

--- a/camacq/helper/__init__.py
+++ b/camacq/helper/__init__.py
@@ -73,7 +73,7 @@ async def setup_all_modules(center, config, package_path, **kwargs):
         The path to the package.
     **kwargs
         Arbitrary keyword arguments. These will be passed to
-        setup_package and setup_module functions.
+        setup_module and setup_module functions.
     """
     imported_pkg = import_module(package_path)
     tasks = []
@@ -99,9 +99,6 @@ async def setup_all_modules(center, config, package_path, **kwargs):
 
 def setup_module(center, config, module, **kwargs):
     """Set up module or package."""
-    if hasattr(module, "setup_package"):
-        _LOGGER.info("Setting up %s package", module.__name__)
-        return center.create_task(module.setup_package(center, config, **kwargs))
     if hasattr(module, "setup_module"):
         _LOGGER.info("Setting up %s module", module.__name__)
         return center.create_task(module.setup_module(center, config, **kwargs))

--- a/camacq/helper/__init__.py
+++ b/camacq/helper/__init__.py
@@ -72,8 +72,8 @@ async def setup_all_modules(center, config, package_path, **kwargs):
     package_path : str
         The path to the package.
     **kwargs
-        Arbitrary keyword arguments. These will be passed to
-        setup_module and setup_module functions.
+        Arbitrary keyword arguments. These will be passed to the
+        setup_module functions.
     """
     imported_pkg = import_module(package_path)
     tasks = []

--- a/camacq/plugins/__init__.py
+++ b/camacq/plugins/__init__.py
@@ -3,10 +3,10 @@ import asyncio
 
 import pkg_resources
 
-from camacq.helper import setup_module
+from camacq.helper import setup_module as setup
 
 
-async def setup_package(center, config):
+async def setup_module(center, config):
     """Set up the plugins package.
 
     Parameters
@@ -19,7 +19,7 @@ async def setup_package(center, config):
     plugins = await center.add_executor_job(get_plugins)
     tasks = []
     for module in plugins.values():
-        task = setup_module(center, config, module)
+        task = setup(center, config, module)
         if task:
             tasks.append(task)
     if tasks:

--- a/camacq/plugins/__init__.py
+++ b/camacq/plugins/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 
 import pkg_resources
 
-from camacq.helper import setup_module as setup
+from camacq.helper import setup_one_module
 
 
 async def setup_module(center, config):
@@ -19,7 +19,7 @@ async def setup_module(center, config):
     plugins = await center.add_executor_job(get_plugins)
     tasks = []
     for module in plugins.values():
-        task = setup(center, config, module)
+        task = setup_one_module(center, config, module)
         if task:
             tasks.append(task)
     if tasks:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,13 @@ CONFIG = {
     "install_requires": REQUIRES,
     "packages": find_packages(exclude=["contrib", "docs", "tests*"]),
     "include_package_data": True,
-    "entry_points": {"console_scripts": ["camacq = camacq.__main__:main"]},
+    "entry_points": {
+        "console_scripts": ["camacq = camacq.__main__:main"],
+        "camacq.plugins": [
+            "gain = camacq.plugins.gain",
+            "rename_image = camacq.plugins.rename_image",
+        ],
+    },
     "name": "camacq",
     "zip_safe": False,
     "classifiers": CLASSIFIERS,

--- a/tests/api/leica/test_leica.py
+++ b/tests/api/leica/test_leica.py
@@ -18,7 +18,7 @@ from camacq.api.leica import (
     LeicaImageEvent,
     LeicaStartCommandEvent,
     LeicaStopCommandEvent,
-    setup_package,
+    setup_module as leica_setup,
 )
 
 # pylint: disable=redefined-outer-name, len-as-condition
@@ -37,10 +37,10 @@ def api(center):
         """Register a mock api package."""
         base_api.register_api(center, mock_api)
 
-    with asynctest.patch("camacq.api.leica.setup_package") as leica_setup:
+    with asynctest.patch("camacq.api.leica.setup_module") as leica_setup:
         leica_setup.side_effect = register_mock_api
         center.loop.run_until_complete(
-            base_api.setup_package(center, {"api": {"leica": {}}})
+            base_api.setup_module(center, {"api": {"leica": {}}})
         )
         yield mock_api
 
@@ -65,7 +65,7 @@ async def test_setup_bad_socket(center, caplog, api):
     """Test setup leica api package with bad host or port."""
     api.client.connect.side_effect = OSError()
     config = {"api": {"leica": {}}}
-    await setup_package(center, config)
+    await leica_setup(center, config)
     assert "Connecting to server localhost failed:" in caplog.text
 
 
@@ -193,7 +193,7 @@ async def test_start_listen(center, caplog):
             AsyncCAM(loop=center.loop)
         )
         mock_cam.receive.return_value = mock_receive()
-        await setup_package(center, config)
+        await leica_setup(center, config)
         await center.wait_for()
         await center.end(0)
 

--- a/tests/automations/test_automations.py
+++ b/tests/automations/test_automations.py
@@ -55,10 +55,10 @@ def mock_api(center):
         """Register a mock api package."""
         api.register_api(center, _mock_api)
 
-    with asynctest.patch("camacq.api.leica.setup_package") as leica_setup:
+    with asynctest.patch("camacq.api.leica.setup_module") as leica_setup:
         leica_setup.side_effect = register_mock_api
         center.loop.run_until_complete(
-            api.setup_package(center, {"api": {"leica": None}})
+            api.setup_module(center, {"api": {"leica": None}})
         )
         yield _mock_api
 
@@ -84,7 +84,7 @@ async def test_setup_automation(center):
     config = await center.add_executor_job(YAML(typ="safe").load, config)
     await sample_mod.setup_module(center, config)
     assert "set_well" in center.actions.actions["sample"]
-    await automations.setup_package(center, config)
+    await automations.setup_module(center, config)
     assert "toggle" in center.actions.actions["automations"]
     automation = center.data["camacq.automations"]["test_automation"]
     assert automation.enabled
@@ -127,7 +127,7 @@ async def test_channel_event(center, mock_api):
 
     config = await center.add_executor_job(YAML(typ="safe").load, config)
     await sample_mod.setup_module(center, config)
-    await automations.setup_package(center, config)
+    await automations.setup_module(center, config)
     automation = center.data["camacq.automations"]["set_channel_gain"]
     assert automation.enabled
 
@@ -165,7 +165,7 @@ async def test_condition(center, mock_api):
 
     config = await center.add_executor_job(YAML(typ="safe").load, config)
     await sample_mod.setup_module(center, config)
-    await automations.setup_package(center, config)
+    await automations.setup_module(center, config)
     automation = center.data["camacq.automations"]["add_exp_job"]
     assert automation.enabled
 
@@ -204,7 +204,7 @@ async def test_nested_condition(center, mock_api):
 
     config = await center.add_executor_job(YAML(typ="safe").load, config)
     await sample_mod.setup_module(center, config)
-    await automations.setup_package(center, config)
+    await automations.setup_module(center, config)
     automation = center.data["camacq.automations"]["add_exp_job"]
     assert automation.enabled
     assert "send" in center.actions.actions["command"]
@@ -271,7 +271,7 @@ async def test_sample_access(center, mock_api):
 
     config = await center.add_executor_job(YAML(typ="safe").load, config)
     await sample_mod.setup_module(center, config)
-    await automations.setup_package(center, config)
+    await automations.setup_module(center, config)
     automation = center.data["camacq.automations"]["set_img_ok"]
     assert automation.enabled
     await center.sample.set_plate("00")
@@ -312,7 +312,7 @@ async def test_delay_action(center, mock_api, caplog):
     """
     caplog.set_level(logging.INFO)
     config = await center.add_executor_job(YAML(typ="safe").load, config)
-    await automations.setup_package(center, config)
+    await automations.setup_module(center, config)
     automation = center.data["camacq.automations"]["test_delay"]
     assert automation.enabled
     event = CamAcqStartEvent({"test_data": "start"})

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.asyncio  # pylint: disable=invalid-name
 @pytest.fixture
 def mock_leica_setup():
     """Mock setup package."""
-    with asynctest.patch("camacq.api.leica.setup_package") as mock_setup:
+    with asynctest.patch("camacq.api.leica.setup_module") as mock_setup:
         yield mock_setup
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -37,7 +37,7 @@ def api_fixture(center):
         """Register a mock api package."""
         base_api.register_api(center, mock_api)
 
-    with asynctest.patch("camacq.api.leica.setup_package") as leica_setup:
+    with asynctest.patch("camacq.api.leica.setup_module") as leica_setup:
         leica_setup.side_effect = register_mock_api
         yield mock_api
 


### PR DESCRIPTION
To install a custom plugin, create a Python package with a `setup.py` module that implements the entry_points interface with key `"camacq.plugins"`.

```py
setup(
    ...
    entry_points={"camacq.plugins": "plugin_a = package_a.plugin_a"},
    ...
)
```

See the packaging [docs](https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata) for details.

`camacq` will automatically load installed modules or packages that implement this entry_point.

Add a `setup_module` coroutine function in the module or package. This function will be awaited with `center` and `config` as arguments.

```py
async def setup_module(center, config):
    """Set up the plugin package."""
```

closes #127 