### PR TITLE
Add start and stop delay

### DIFF
--- a/camacq/plugins/leica/__init__.py
+++ b/camacq/plugins/leica/__init__.py
@@ -31,6 +31,7 @@ LEICA_IMAGE_EVENT = "leica_image_event"
 REL_IMAGE_PATH = "relpath"
 SCAN_FINISHED = "scanfinished"
 SCAN_STARTED = "scanstart"
+START_STOP_DELAY = 2.0
 
 
 async def setup_module(center, config):
@@ -161,10 +162,15 @@ class LeicaApi(Api):
     async def start_imaging(self):
         """Send a command to the microscope to start the imaging."""
         await self._start_stop_imaging(start(), LEICA_START_COMMAND_EVENT, SCAN_STARTED)
+        # A delay is needed after starting.
+        await asyncio.sleep(START_STOP_DELAY)
 
     async def stop_imaging(self):
         """Send a command to the microscope to stop the imaging."""
+        # A delay is needed before and after stopping.
+        await asyncio.sleep(START_STOP_DELAY)
         await self._start_stop_imaging(stop(), LEICA_STOP_COMMAND_EVENT, SCAN_FINISHED)
+        await asyncio.sleep(START_STOP_DELAY)
 
     async def _start_stop_imaging(self, cmd, event, ack_cmd):
         """Send a command to the microscope to start or stop the imaging."""

--- a/tests/plugins/leica/test_leica.py
+++ b/tests/plugins/leica/test_leica.py
@@ -37,7 +37,9 @@ def api(center):
         """Register a mock api package."""
         base_api.register_api(center, mock_api)
 
-    with asynctest.patch("camacq.plugins.leica.setup_module") as leica_setup:
+    with asynctest.patch(
+        "camacq.plugins.leica.setup_module"
+    ) as leica_setup, asynctest.patch("camacq.plugins.leica.START_STOP_DELAY", 0.0):
         leica_setup.side_effect = register_mock_api
         center.loop.run_until_complete(base_api.setup_module(center, config))
         yield mock_api


### PR DESCRIPTION
-  A delay is needed after starting imaging and before and after stopping imaging for the Leica microscope. This makes sure the microscope has time to move into position and also to not stop scanning until the last image is saved.