### PR TITLE
Drop pycodestyle requirement

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,5 +1,4 @@
 black==20.8b1
 flake8==3.8.4
-pycodestyle==2.6.0
 pydocstyle==5.1.1
 pylint==2.7.2


### PR DESCRIPTION
- pycodestyle is a dependency of flake8. We don't need to require pycodestyle explicitly.