### PR TITLE
Hide dependencies in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,6 +4,10 @@ categories:
   - title: "Breaking changes:"
     labels:
       - "breaking change"
+  - title: "⬆️ Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
 template: |
   ## Merged pull requests:
 


### PR DESCRIPTION
- Clean up release notes by hiding dependencies.