### PR TITLE
Remove support for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
 
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.10
   install:
     - requirements: requirements_docs.txt
     - path: .

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python project to control microscope through client-server program.
 
 ## Install
 
-- Install the camacq package. Python version 3.8+ is supported.
+- Install the camacq package. Python version 3.10+ is supported.
 
     ```sh
     # Check python version.

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ CLASSIFIERS = [
     "License :: OSI Approved :: Apache Software License",
     # Specify the Python versions you support here. In particular, ensure
     # that you indicate whether you support Python 2, Python 3 or both.
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
 
@@ -52,7 +50,7 @@ CONFIG = {
     "license": "Apache-2.0",
     "author_email": "marhje52@gmail.com",
     "version": VERSION,
-    "python_requires": ">=3.8",
+    "python_requires": ">=3.10",
     "install_requires": REQUIRES,
     "packages": find_packages(exclude=["contrib", "docs", "tests*"]),
     "include_package_data": True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py38, py39, py310, lint, docs
+envlist = py310, lint, docs
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.8: py38, docs, lint
-    3.9: py39
-    3.10: py310
+    3.10: py310, docs, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
- Python 3.8 is end of life since October 2024.
- Scientific Python currently only supports Python 3.10 - 3.13.